### PR TITLE
Issue with question mark in query strings

### DIFF
--- a/buster/buster.py
+++ b/buster/buster.py
@@ -43,6 +43,17 @@ def main():
                    "--no-parent "             # don't go to parent level
                    "--directory-prefix {1} "  # download contents to static/ folder
                    "--no-host-directories "   # don't create domain named folder
+                   "--restrict-file-names=windows "
+                   "{0}").format(arguments['--domain'], static_path)
+        os.system(command)
+  
+        command = ("wget "
+                   "--recursive "             # follow links to download entire site
+                   "--convert-links "         # make links relative
+                   "--page-requisites "       # grab everything: css / inlined images
+                   "--no-parent "             # don't go to parent level
+                   "--directory-prefix {1} "  # download contents to static/ folder
+                   "--no-host-directories "   # don't create domain named folder
                    "--restrict-file-names=unix "
                    "{0}").format(arguments['--domain'], static_path)
         os.system(command)


### PR DESCRIPTION
NTFS doesn't allow question marks in the filenames, so "--restrict-file-names=windows" wget's option seems to solve that. However, "--convert-links" option would also replace every question mark in queried urls with "@" character, therefore, making browser to look for the files with "@" character in the file path (e.g. /assets/css/screen.css@v=6f5481b116"). Cheap and dirty option is to get windows-compatible assets (js and css) first, and then regenerate html files in unix mode, replacing /assets/css/screen.css@v=6f5481b116" back to /assets/css/screen.css?v=6f5481b116" in html files. That takes more time, but also seems looking cleaner to me.
